### PR TITLE
remove comments before merging ldscripts

### DIFF
--- a/libopencm3.py
+++ b/libopencm3.py
@@ -117,7 +117,9 @@ def get_source_files(src_dir):
 
 
 def merge_ld_scripts(main_ld_file):
-
+    # re to find multi-line comments
+    commentsre = re.compile(r"/\*.*?\*/", re.M|re.DOTALL)
+    
     def _include_callback(match):
         included_ld_file = match.group(1)
         # search included ld file in lib directories
@@ -125,12 +127,12 @@ def merge_ld_scripts(main_ld_file):
             if included_ld_file not in files:
                 continue
             with open(join(root, included_ld_file)) as fp:
-                return fp.read()
+                return commentsre.sub("", fp.read())
         return match.group(0)
 
     content = ""
     with open(main_ld_file) as f:
-        content = f.read()
+        content = commentsre.sub("", f.read())
 
     incre = re.compile(r"^INCLUDE\s+\"?([^\.]+\.ld)\"?", re.M)
     with open(main_ld_file, "w") as f:


### PR DESCRIPTION
STM32 ldscripts use INCLUDE to include [core-m-generic.ld](https://github.com/libopencm3/libopencm3/blob/master/lib/cortex-m-generic.ld). This include file has another INCLUDE in the example comment which causes additional unwanted includes. Remove multiline-comments from base ldscript as well as all included parts to prevent this.

With this change I am able to build for a custom STM32L0xx8 board using the master of the libopencm3 repo cloned to ~/.platformio/packages/framework-libopencm3, with just package.json added from the original framework-libopencm3 PIO package.