### PR TITLE
Enhancements for ldscripts & new versions of libopencm3

### DIFF
--- a/libopencm3.py
+++ b/libopencm3.py
@@ -54,15 +54,15 @@ def find_ldscript(src_dir):
 
     board_ldscript = env.BoardConfig().get("build.ldscript", "")
 
-    if len(matches) == 1:
+    if isfile(join(PROJECT_DIR, board_ldscript)):
+        # allow to supply an ldscript from the project directory
+        ldscript = join(PROJECT_DIR, board_ldscript)
+    elif len(matches) == 1:
         # if there was only one, assume it's good for the whole series (i guess?)
         ldscript = matches[0]
     elif isfile(join(src_dir, board_ldscript)):
         # if more/less than one, rely on the user specifying which to use
         ldscript = join(src_dir, board_ldscript)
-    elif isfile(join(PROJECT_DIR, board_ldscript)):
-        # allow to supply an ldscript from the project directory
-        ldscript = join(PROJECT_DIR, board_ldscript)
 
     return ldscript
 

--- a/libopencm3.py
+++ b/libopencm3.py
@@ -174,3 +174,34 @@ env.Append(
         join(FRAMEWORK_DIR, "lib")
     ]
 )
+
+env.Append(
+    ASFLAGS=["-x", "assembler-with-cpp"],
+
+    CCFLAGS=[
+        "-fno-common", # place uninitialized global vars in BSS
+        "-ffunction-sections",  # place each function in its own section
+        "-fdata-sections", # same for data
+        "-mthumb",
+    ],
+
+    LINKFLAGS=[
+        "-Wl,--gc-sections",
+        "-nostartfiles",
+        "-nostdlib",
+        "-mthumb",
+    ],
+)
+
+if "BOARD" in env:
+    env.Append(
+        CCFLAGS=[
+            "-mcpu=%s" % env.BoardConfig().get("build.cpu")
+        ],
+        LINKFLAGS=[
+            "-mcpu=%s" % env.BoardConfig().get("build.cpu")
+        ]
+    )
+
+# copy CCFLAGS to ASFLAGS (-x assembler-with-cpp mode)
+env.Append(ASFLAGS=env.get("CCFLAGS", [])[:])

--- a/libopencm3.py
+++ b/libopencm3.py
@@ -45,7 +45,7 @@ def find_ldscript(src_dir):
     ldscript = None
     matches = []
 
-    # find any chip-specific ldscripts included in libopencm3 lib/stm32/<series>/
+    # find any chip-specific ldscripts included with libopencm3 (it has many but not all)
     for item in sorted(listdir(src_dir)):
         _path = join(src_dir, item)
         if not isfile(_path) or not item.endswith(".ld"):
@@ -168,7 +168,7 @@ libs.append(env.Library(
 
 env.Append(LIBS=libs)
 
-# make sure gcc can find the base ldscript "cortex-m-generic.ld" which is in this dir
+# make sure gcc can find the ldscripts included in libopencm3
 env.Append(
     LIBPATH=[
         join(FRAMEWORK_DIR, "lib")

--- a/libopencm3.py
+++ b/libopencm3.py
@@ -149,8 +149,6 @@ env.Append(
 generate_nvic_files()
 
 ldscript_path = find_ldscript(root_dir)
-# override ldscript by libopencm3
-assert "LDSCRIPT_PATH" in env
 env.Replace(
     LDSCRIPT_PATH=ldscript_path
 )


### PR DESCRIPTION
My original reason for digging into this was that I needed a custom ldscript for my custom board, and while I can easily specify a custom board in my project, I could not build for it with libopencm3 because neither it nor the ststm32 platform include an ldscript for my specific chip.

While in here, I also decided to try using the latest master of libopencm3 and ran into a couple issues, so tried to update this to support that at the same time, while also not breaking this for the version of libopencm3 currently distributed by PlatformIO.

Summary of changes:
- allow specifying an ldscript that is relative to the project
- remove code that reimplements ld's `#INCLUDE` directive, just add the framework's lib dir to the `LIBPATH` env var and let ld do its thing
    - this also enables a project-relative ldscript can include framework ldscripts, as is conventional for libopencm3-based projects
    - would remove need for #2 – though i want to give a shout-out to @k3a because that PR helped me get started on this path
- remove an assertion that the `LDSCRIPT_PATH` env var was set, as it seems to me that if/when a chip-specific ldscript can be found in libopencm3 then there's no reason to require it to be set in the board config
- add some basic flags to `ASFLAGS`, `CCFLAGS` and `LINKFLAGS` – just enough to be safe defaults and get things to work

I really hope this can be useful, please let me know if there are any questions or more work needed to get it merged!