### PR TITLE
Regex fix to Makefile parser.

### DIFF
--- a/libopencm3.py
+++ b/libopencm3.py
@@ -83,13 +83,13 @@ def parse_makefile_data(makefile):
             data["includes"].append(match.group(1))
 
         # fetch "vpath"s
-        re_vpath = re.compile(r"^VPATH\s+\+?=\s+([^\r\n]+)", re.M)
+        re_vpath = re.compile(r"^VPATH\s*\+?=\s*([^\r\n]+)", re.M)
         for match in re_vpath.finditer(content):
             data["vpath"] += match.group(1).split(":")
 
         # fetch obj files
         objs_match = re.search(
-            r"^OBJS\s+\+?=\s+([^\.]+\.o\s*(?:\s+\\s+)?)+", content, re.M)
+            r"^OBJS\s*\+?=\s*([^\.]+\.o\s*(?:\s+\\s+)?)+", content, re.M)
         assert objs_match
         data["objs"] = re.sub(
             r"(OBJS|[\+=\\\s]+)", "\n", objs_match.group(0)).split()


### PR DESCRIPTION
The regex strings (`\s+\+?=\s+`) inside `parse_makefile_data` incorrectly assume that there must be whitespace surrounding the assignment operator (1). I found this because the Makefile (2) for the board I was trying to build for had (going against what looks to be their normal format) no whitespace after the assignment operator.
(1) "_Whitespace around the variable name and immediately after the ‘=’ is ignored._" - https://www.gnu.org/software/make/manual/html_node/Setting.html
(2) https://github.com/libopencm3/libopencm3/blob/master/lib/stm32/g0/Makefile